### PR TITLE
feat: add a script to create new components

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,28 @@ We use [Github issues](https://github.com/onu-ui/onu-ui/issues) for bug reports 
 
 > I know DX is not very good, if you have a good method, welcome to submit a PR
 
+## Components Guidelines
+
+Run `pnpm run new <component name>` to create a new component.
+
+For instance, you can run `pnpm run new button` to automatically generate the `button` directory along with its base template. and will also add the new component to the root `package.json` as a dependency.
+
+### Directory Structure
+
+```
+svelte-ui
+├─ components
+│  ├─ Button
+│  │  ├─ __test__
+│  │  │  └─ button.spec.ts
+│  │  ├─ package.json
+│  │  ├─ src
+│  │  │  ├─ index.svelte
+│  │  │  ├─ index.ts
+│  │  │  └─ types.d.ts
+│  │  └─ tsconfig.json
+```
+
 ## Commit Guidelines
 
 Commit messages are required to follow the [conventional-changelog standard](https://www.conventionalcommits.org/en/v1.0.0/):

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -34,6 +34,28 @@
 
 > 我知道DX并不是很好，如果你有好的方法欢迎提交PR
 
+## 组件指南
+
+使用`pnpm run new <组建名>`创建新的组件。
+
+例如，运行`pnpm run new button`，自动创建一个名为`button`组件的目录及基本的模版，并将其作为依赖添加到根目录的`package.json`中。
+
+### 目录结构
+
+```
+svelte-ui
+├─ components
+│  ├─ Button
+│  │  ├─ __test__
+│  │  │  └─ button.spec.ts
+│  │  ├─ package.json
+│  │  ├─ src
+│  │  │  ├─ index.svelte
+│  │  │  ├─ index.ts
+│  │  │  └─ types.d.ts
+│  │  └─ tsconfig.json
+```
+
 ## Commit 指南
 
 Commit messages 请遵循[conventional-changelog 标准](https://www.conventionalcommits.org/en/v1.0.0/)：

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"clean:deps": "esno scripts/clean-deps.js && node scripts/clean-root-deps.js",
 		"prepare": "npx simple-git-hooks",
 		"update:deps": "npx taze -w -r major && pnpm run init",
-		"new": "esno scripts/new-component.ts"
+		"create:new:comp": "esno scripts/new-component.ts"
 	},
 	"peerDependencies": {
 		"baiwusanyu-utils": "^1.0.14",

--- a/package.json
+++ b/package.json
@@ -68,14 +68,17 @@
 		"clean:dist": "rimraf dist && esno scripts/clean.js",
 		"clean:deps": "esno scripts/clean-deps.js && node scripts/clean-root-deps.js",
 		"prepare": "npx simple-git-hooks",
-		"update:deps": "npx taze -w -r major && pnpm run init"
+		"update:deps": "npx taze -w -r major && pnpm run init",
+		"new": "esno scripts/new-component.ts"
 	},
 	"peerDependencies": {
+		"baiwusanyu-utils": "^1.0.14",
 		"svelte": "^4.0.0",
-		"unocss": "^0.54.1",
-		"baiwusanyu-utils": "^1.0.14"
+		"unocss": "^0.54.1"
 	},
 	"dependencies": {
+		"baiwusanyu-utils": "^1.0.14",
+		"@ikun-ui/utils": "workspace:*",
 		"@ikun-ui/badge": "workspace:*",
 		"@ikun-ui/button": "workspace:*",
 		"@ikun-ui/button-group": "workspace:*",
@@ -92,14 +95,12 @@
 		"@ikun-ui/modal": "workspace:*",
 		"@ikun-ui/notify": "workspace:*",
 		"@ikun-ui/popover": "workspace:*",
-		"@ikun-ui/radio": "workspace:*",
 		"@ikun-ui/preset": "workspace:*",
+		"@ikun-ui/radio": "workspace:*",
 		"@ikun-ui/select": "workspace:*",
 		"@ikun-ui/switch": "workspace:*",
 		"@ikun-ui/tag": "workspace:*",
-		"@ikun-ui/tooltip": "workspace:*",
-		"@ikun-ui/utils": "workspace:*",
-		"baiwusanyu-utils": "^1.0.14"
+		"@ikun-ui/tooltip": "workspace:*"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.37.0",
@@ -107,7 +108,6 @@
 		"@sveltejs/kit": "^1.22.5",
 		"@sveltejs/package": "^2.2.1",
 		"@sveltejs/vite-plugin-svelte": "^2.4.5",
-		"svelte-preprocess": "latest",
 		"@testing-library/svelte": "^4.0.3",
 		"@types/node": "^20.4.9",
 		"@typescript-eslint/eslint-plugin": "^6.3.0",
@@ -125,6 +125,7 @@
 		"fast-glob": "^3.3.1",
 		"jsdom": "^22.1.0",
 		"npm-run-all": "^4.1.5",
+		"ora": "^7.0.1",
 		"prettier": "^3.0.1",
 		"prettier-plugin-svelte": "^3.0.3",
 		"publint": "^0.2.0",
@@ -133,6 +134,7 @@
 		"simple-git-hooks": "^2.9.0",
 		"svelte": "^4.1.2",
 		"svelte-check": "^3.4.6",
+		"svelte-preprocess": "latest",
 		"tslib": "^2.6.1",
 		"tsup": "^7.2.0",
 		"typescript": "^5.1.6",

--- a/scripts/new-component.ts
+++ b/scripts/new-component.ts
@@ -1,0 +1,276 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { log, setGlobalPrefix, extend, deepClone } from 'baiwusanyu-utils';
+import { kebabToPascal } from '@ikun-ui/utils';
+import ora, { Ora } from 'ora';
+//@ts-ignore
+import { runCommand } from './utils.js';
+const require = createRequire(import.meta.url);
+
+const args = process.argv;
+const originalCompName = args[2];
+const libName = `@ikun-ui/${originalCompName}`;
+
+const __dirname = fileURLToPath(new URL('../', import.meta.url));
+const componentsRoot = 'components/';
+const pkgPath = path.join(__dirname, 'package.json');
+const rootPKG = require(pkgPath);
+
+const upperReg: RegExp = /[A-Z]/;
+
+const compDevDeps = ['@tsconfig/svelte', 'svelte-strip', 'tslib', 'typescript'];
+const getDeps = (dep: string) => `"${dep}": "${rootPKG.dependencies[dep]}"`;
+const _write = async (file: string, content: string, witreSpinner: Ora) => {
+	return new Promise((resolve, reject) => {
+		fs.writeFile(file, content, async (err) => {
+			if (err) {
+				witreSpinner.fail(`failed to create file ${file}, rolling back operation.`);
+				await rollback(err);
+				reject(err);
+				process.exit(1);
+			}
+			witreSpinner.succeed(`file ${file} created successfully.`);
+			resolve(null);
+		});
+	});
+};
+
+const write = (file: string, content: string) => writeFnSpinnerRegister(file, content, _write);
+
+createComponent().catch(async (err) => {
+	await rollback(err);
+	process.exit(1);
+});
+
+async function createComponent() {
+	setGlobalPrefix('[ikun-ui]: ');
+	const compName = createCompName(originalCompName);
+	const compBaseDir = `${componentsRoot}${compName}`;
+	const compMainDir = `${compBaseDir}/src`;
+	const compTestDir = `${compBaseDir}/__test__`;
+	await appendDepToPkg(originalCompName);
+	mkCompDirsSync(compBaseDir, compMainDir, compTestDir);
+	// writes files
+	await Promise.all([
+		writeTsConfig(compBaseDir),
+		writePkgJson(compBaseDir, originalCompName),
+		writeComponent(compMainDir, originalCompName),
+		writeEntry(compMainDir, compName),
+		writeTypeDTs(compMainDir, compName),
+		writeTest(compTestDir, compName, originalCompName)
+	]);
+
+	// excutes the required commands
+	await devDependenciesInstall();
+
+	log(
+		'success',
+		`${originalCompName} has been created successfully. Thank you for your contribution, and enjoy your coding!`
+	);
+}
+function mkCompDirsSync(...dirs: string[]): void {
+	dirs.forEach((dir) => fs.mkdirSync(dir));
+}
+
+/**
+ * checks whether the component name is kabab case, and wether the
+ * component already exists.
+ * returns a string that has been convertd.
+ */
+function createCompName(componentName: string): string {
+	if (!originalCompName || upperReg.test(originalCompName)) {
+		log('error', `Please name a compnent with the kebab case. e.g, pnpm run new check-box`);
+		process.exit(1);
+	}
+	const _compName = kebabToPascal(componentName);
+	const compPath = componentsRoot + kebabToPascal(componentName);
+	if (fs.existsSync(compPath)) {
+		log('error', `${_compName} already exists`);
+		process.exit(1);
+	}
+	return _compName;
+}
+
+async function writeTsConfig(baseDir: string) {
+	const file = `${baseDir}/tsconfig.json`;
+	const tsConfigContent = `{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+
+  "compilerOptions": {
+    "noImplicitAny": true,
+    "strict": true,
+    "declaration": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte"],
+  "exclude": ["node_modules/*", "**/*.spec.ts"]
+}  
+  `;
+
+	write(file, tsConfigContent);
+}
+
+async function writePkgJson(baseDir: string, originalCompName: string) {
+	const file = `${baseDir}/package.json`;
+	const version = rootPKG.version;
+	const pkgContent = `{
+  "name": "@ikun-ui/${originalCompName}",
+  "version": "${version}",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "svelte": "dist/index.js",
+  "types": "src/index.ts",
+  "keywords": [
+    "svelte",
+    "svelte3",
+    "web component",
+    "component",
+    "react",
+    "vue",
+    "svelte-kit",
+    "dx"
+  ],
+  "scripts": {
+    "build": "npm run build:js && npm run build:svelte",
+    "build:js": "tsc -p . --outDir dist/ --rootDir src/",
+    "build:svelte": "svelte-strip strip src/ dist",
+    "publish:npm": "pnpm publish --no-git-checks --access public"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@ikun-ui/icon": "workspace:*",
+    "@ikun-ui/utils": "workspace:*",
+    ${getDeps('baiwusanyu-utils')}
+  }
+}
+  `;
+	write(file, pkgContent);
+}
+
+async function writeComponent(baseDir: string, originalCompName: string) {
+	const file = `${baseDir}/index.svelte`;
+	const svelteContent = `<script lang="ts">
+  import { getPrefixCls, createCls } from '@ikun-ui/utils';
+  
+  export let cls: string = '';
+  export let attrs: Record<string, string> = {};
+  
+  const prefixCls = getPrefixCls('${originalCompName}');
+
+  $: cnames = createCls(prefixCls, {
+    [\`$\{prefixCls}--base\`]: true
+  }, cls);
+</script>
+
+<div class={cnames} {...$$restProps} {...attrs}></div>
+  `;
+	write(file, svelteContent);
+}
+
+async function writeEntry(baseDir: string, compName: string) {
+	const file = `${baseDir}/index.ts`;
+	const entryContent = `/// <reference types="./types" />
+import ${compName} from './index.svelte';
+export { ${compName} as K${compName} };
+
+export default ${compName};`;
+	write(file, entryContent);
+}
+
+async function writeTypeDTs(baseDir: string, compName: string) {
+	const file = `${baseDir}/types.d.ts`;
+	const typeDtsContent = `/// <reference types="svelte" />
+export type K${compName}Props = {
+  cls: string,
+  attrs: Record<string, string>
+}`;
+	write(file, typeDtsContent);
+}
+
+/**
+ * add dependence of current component into the package.json dependeces.
+ */
+async function appendDepToPkg(compName: string) {
+	const pkgCopy = deepClone(rootPKG);
+	const depName = `@ikun-ui/${compName}`;
+	if (depName in pkgCopy.dependencies) {
+		log('error', `${depName} alredy exists in the pakeage.json.`);
+		process.exit(1);
+	}
+	pkgCopy.dependencies = extend(pkgCopy.dependencies, { [`${depName}`]: 'workspace:*' });
+	write(pkgPath, JSON.stringify(pkgCopy, null, 2));
+}
+
+/**
+ * to installs the devDependencies.
+ *
+ * this section is can not be written in the `writePkgJson`. the reason is that thier
+ * versions might change in future, and thier are not preset in root `package.json`.
+ */
+async function devDependenciesInstall() {
+	const spinners = ora('installing dependencies...').start();
+	await runCommand(`pnpm -F=${libName} install ${compDevDeps.join(' ')} --save-dev`, __dirname, {
+		silent: true
+	}).catch((err: Error['message']) => {
+		spinners.fail(`Failed to install dependencies. Please check the issue and try again.\n ${err}`);
+	});
+	spinners.clear();
+	spinners.succeed('dependencies installed successfully.');
+}
+
+async function writeTest(baseDir: string, compName: string, originalCompName: string) {
+	const file = `${baseDir}/${originalCompName}.spec.ts`;
+	const testContent = `import { afterEach, expect, test, describe, beforeEach } from 'vitest';
+import K${compName} from '../src';
+
+let host: HTMLElement;
+
+const initHost = () => {
+	host = document.createElement('div');
+	host.setAttribute('id', 'host');
+	document.body.appendChild(host);
+};
+beforeEach(() => {
+	initHost();
+});
+afterEach(() => {
+	host.remove();
+});
+	
+describe('Test: K${compName}', () => {
+	test('props: cls', async () => {
+		const instance = new K${compName}({
+			target: host,
+			props: {
+				cls: 'k-${originalCompName}--test'
+			}
+		});
+		expect(instance).toBeTruthy();
+		expect(
+			(host as HTMLElement)!.innerHTML.includes('k-${originalCompName}--test')
+		).toBeTruthy();
+		expect(host.innerHTML).matchSnapshot();
+	});
+})
+	`;
+	await write(file, testContent);
+}
+
+/**
+ * if any files have been changed but the scripts encounter errors, perform a rollback to
+ * a previous state.
+ */
+async function rollback(err: any) {
+	log('error', `rollback err: ${err}`);
+	await write(pkgPath, JSON.stringify(rootPKG, null, 2));
+	process.exit(1);
+}
+
+async function writeFnSpinnerRegister(file: string, content: string, fn: typeof _write) {
+	const witreSpinner = ora(`createing file: ${file}`).start();
+	await fn(file, content, witreSpinner);
+}

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -13,7 +13,8 @@ export async function runCommand(command, dir, userOptions) {
 					shell: true,
 					encoding: 'GBK',
 					async: true,
-					silent: userOptions?.silent === undefined ? true : userOptions?.silent
+					silent: userOptions?.silent === undefined ? true : userOptions?.silent,
+					...userOptions
 				},
 				(code, output, err) => {
 					if (code === 0) {
@@ -23,7 +24,7 @@ export async function runCommand(command, dir, userOptions) {
 					}
 
 					const outputStr = output.toString();
-					if (outputStr) {
+					if (outputStr && !(userOptions?.silent ?? true)) {
 						console.log(outputStr);
 					}
 				}

--- a/utils/src/class-names.ts
+++ b/utils/src/class-names.ts
@@ -31,3 +31,5 @@ export function createCls(
 	}
 	return classnames.join(' ');
 }
+
+export const getPrefixCls = (cls: string) => `k-${cls}`;

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -1,3 +1,5 @@
 export * from './types';
 
-export { createCls } from './class-names';
+export { createCls, getPrefixCls } from './class-names';
+
+export { kebabToPascal } from './utils';

--- a/utils/src/utils.ts
+++ b/utils/src/utils.ts
@@ -4,3 +4,22 @@ export const isRewritten = (target: Record<string, any>): boolean => {
 		!target.toString.toString().includes('[native code]')
 	);
 };
+
+/**
+ * to converts the kebab case into pascal case
+ * e.g., pnpm run new check-box -> `CheckBox`
+ */
+export const kebabToPascal = (name: string): string => {
+	let camelCase: string = name[0].toLocaleUpperCase();
+	let point: number = 1;
+	while (point < name.length) {
+		if (name[point] === '-') {
+			++point;
+			camelCase += name[point].toUpperCase();
+		} else {
+			camelCase += name[point];
+		}
+		point++;
+	}
+	return camelCase;
+};


### PR DESCRIPTION
Run `pnpm run new <component name>` to create a new component.

For instance, you can run `pnpm run new new-test` to automatically gennerate the `new-test` directory along with its base template. 

```
svelte-ui
├─ components
│  ├─NewTest
│  │  ├─ __test__
│  │  │  └─ new-test.spec.ts
│  │  ├─ package.json
│  │  ├─ src
│  │  │  ├─ index.svelte
│  │  │  ├─ index.ts
│  │  │  └─ types.d.ts
│  │  └─ tsconfig.json
```

and will also add the new component to the root `package.json` as a dependency.

preview:

<img width="791" alt="image" src="https://github.com/ikun-svelte/ikun-ui/assets/49926816/d65b9c9b-d171-4e72-9867-642891bef0fd">

<img width="915" alt="image" src="https://github.com/ikun-svelte/ikun-ui/assets/49926816/c0d28c48-d68b-4533-ae90-ae1aa5942d05">