### PR TITLE
feat: Add useCompositionInput for better input composition

### DIFF
--- a/components/Input/src/types.d.ts
+++ b/components/Input/src/types.d.ts
@@ -9,4 +9,5 @@ export type KInputProps = {
 	errorMsg: string;
 	cls: string;
 	attrs: Record<string, string>;
+	useCompositionInput: boolean;
 };

--- a/docs/components/KInput.md
+++ b/docs/components/KInput.md
@@ -43,15 +43,16 @@ Disable the input through the disabled attribute
 
 ## Input Props
 
-| Name        | Type                     | Default | Description                                                      |
-| ----------- | ------------------------ | ------- | ---------------------------------------------------------------- |
-| value       | `string`                 | `-`     | Binding value                                                    |
-| iconPrefix  | `string`                 | `-`     | The class name of the prefix icon, following the unocss standard |
-| iconSuffix  | `string`                 | `-`     | The class name of the suffix icon, following the unocss standard |
-| placeholder | `string`                 | `false` | Input's placeholder                                              |
-| disabled    | `boolean`                | `false` | Disable the Input                                                |
-| cls         | `string`                 | `-`     | Additional class                                                 |
-| attrs       | `Record<string, string>` | `{}`    | Additional attributes                                            |
+| Name                | Type                     | Default | Description                                                      |
+| ------------------- | ------------------------ | ------- | ---------------------------------------------------------------- |
+| value               | `string`                 | `-`     | Binding value                                                    |
+| iconPrefix          | `string`                 | `-`     | The class name of the prefix icon, following the unocss standard |
+| iconSuffix          | `string`                 | `-`     | The class name of the suffix icon, following the unocss standard |
+| placeholder         | `string`                 | `false` | Input's placeholder                                              |
+| disabled            | `boolean`                | `false` | Disable the Input                                                |
+| useCompositionInput | `boolean`                | `false` | Bind value will be updated after the composition input ends      |
+| cls                 | `string`                 | `-`     | Additional class                                                 |
+| attrs               | `Record<string, string>` | `{}`    | Additional attributes                                            |
 
 ## Input Events
 
@@ -63,6 +64,9 @@ Disable the input through the disabled attribute
 | change           | Event fired when the `value` is changes                            | `(value: Event)=> void`                  |
 | compositionstart | The compositionstart event is fired when a text composition system | `(e: CompositionEvent)=> void`           |
 | compositionend   | The compositionend event is fired when a text composition system   | `(e: CompositionEvent)=> void`           |
+| compositionInput | Event fired when enable `useCompositionInput`                      | `(value: Event)=> void`                  |
+
+> > > > > > > Stashed changes
 
 ## Input Slots
 

--- a/play/src/routes/+page.svelte
+++ b/play/src/routes/+page.svelte
@@ -93,6 +93,9 @@
 		on:input={() => {
 			console.log('on:input =>', inputValue);
 		}}
+		on:compositionInput={() => {
+			console.log('on:compositionInput =>', inputValue);
+		}}
 	></KInput>
 </div>
 


### PR DESCRIPTION
添加了 `useCompositionInput` **API** 和 `compositionInput` 事件，启用 `useCompositionInput` bind value 将会在组合输入完成后修改，不影响 `input` 事件， `compositionInput` 事件将会在 value 修改后触发