### PR TITLE
refactor(utils.ts): a better kebabToPascal

### DIFF
--- a/utils/src/utils.ts
+++ b/utils/src/utils.ts
@@ -10,16 +10,8 @@ export const isRewritten = (target: Record<string, any>): boolean => {
  * e.g., pnpm run new check-box -> `CheckBox`
  */
 export const kebabToPascal = (name: string): string => {
-	let camelCase: string = name[0].toLocaleUpperCase();
-	let point: number = 1;
-	while (point < name.length) {
-		if (name[point] === '-') {
-			++point;
-			camelCase += name[point].toUpperCase();
-		} else {
-			camelCase += name[point];
-		}
-		point++;
-	}
-	return camelCase;
+	return name
+		.split('-')
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join('');
 };


### PR DESCRIPTION
By using the old function I had unexpected results plus the function is too long,

```js
"-first-test" => "-firstTest" // Must be `FirstTest`
"first-test-" => TypeError // Must be `FirstTest`
```