### PR TITLE
refactor: Icon component

### DIFF
--- a/components/Icon/src/index.svelte
+++ b/components/Icon/src/index.svelte
@@ -2,18 +2,14 @@
 	import { createEventDispatcher } from 'svelte';
 	import { clsx, type ClassValue } from 'clsx';
 
-	export let icon: string = '';
+	export let icon: string;
 	export let btn = false;
 	export let width = '24px';
 	export let height = '24px';
 	export let color = '';
 	export let attrs = {};
-	export let cls: ClassValue = '';
+	export let cls: ClassValue = undefined;
 
-	$: cnames = clsx(cls);
-
-	$: iconInner = icon;
-	$: tag = btn ? 'button' : '';
 	const dispatch = createEventDispatcher();
 	const handleClick = (e: Event) => {
 		dispatch('click', e);
@@ -21,15 +17,13 @@
 </script>
 
 <div
-	role={tag}
+	role={btn ? 'button' : undefined}
 	aria-hidden="true"
-	{...attrs}
-	class="k-icon--base k-icon--base__dark {btn ? 'cursor-pointer' : ''} {cnames}"
+	class={clsx(cls, ['k-icon--base k-icon--base__dark'], {
+		'cursor-pointer': btn
+	})}
 	on:click={handleClick}
+	{...attrs}
 >
-	<div
-		class="{iconInner} k-icon-transition {color}"
-		style="
-		 width: {width}; height:{height};"
-	/>
+	<div class={clsx(icon, color, ['k-icon-transition'])} style:width style:height />
 </div>

--- a/components/Icon/src/index.svelte
+++ b/components/Icon/src/index.svelte
@@ -7,7 +7,7 @@
 	export let width = '24px';
 	export let height = '24px';
 	export let color = '';
-	export let attrs = {};
+	export let attrs: Record<string, string> = {};
 	export let cls: ClassValue = undefined;
 
 	const dispatch = createEventDispatcher();


### PR DESCRIPTION
1. Made `icon` strictly string since that's the purpose of the component.
2. Added typing to props.

One common problem in many components is concatenating classnames with spaces which will lead to extra space in the class if no props were passed, instead we should use `clsx`, I will make a couple of PR's regarding them.