### PR TITLE
chore: optimize package build configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,3 @@ Thanks to everyone who has already contributed to ikun-ui !
 - [svelte](https://github.com/sveltejs/svelte)
 - [unocss](https://github.com/unocss/unocss)
 - [onu-ui](https://github.com/onu-ui/onu-ui)
-
-* 🎯 组件子包目前DEV必须重新打包才能生效
-* 🎯 svelte-strip 和 tsc 打包速度太慢
-* 🎯(准备转向 svelte-kit 的 lib 模板，寻求一种能够dev无序重新构建，无多余内容分包，构建速度快的方式)

--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ Thanks to everyone who has already contributed to ikun-ui !
 - [svelte](https://github.com/sveltejs/svelte)
 - [unocss](https://github.com/unocss/unocss)
 - [onu-ui](https://github.com/onu-ui/onu-ui)
+
+* 🎯 组件子包目前DEV必须重新打包才能生效
+* 🎯 svelte-strip 和 tsc 打包速度太慢
+* 🎯(准备转向 svelte-kit 的 lib 模板，寻求一种能够dev无序重新构建，无多余内容分包，构建速度快的方式)

--- a/components/Alert/package.json
+++ b/components/Alert/package.json
@@ -1,9 +1,9 @@
 {
 	"name": "@ikun-ui/alert",
-	"version": "0.0.11",
+	"version": "0.0.12",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Alert/package.json
+++ b/components/Alert/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/alert",
 	"version": "0.0.12",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Alert/package.json
+++ b/components/Alert/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Alert/tsconfig.json
+++ b/components/Alert/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Avatar/package.json
+++ b/components/Avatar/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/avatar",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Avatar/package.json
+++ b/components/Avatar/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Avatar/package.json
+++ b/components/Avatar/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/avatar",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Avatar/tsconfig.json
+++ b/components/Avatar/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Backtop/package.json
+++ b/components/Backtop/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/backtop",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Backtop/package.json
+++ b/components/Backtop/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/backtop",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Backtop/package.json
+++ b/components/Backtop/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Backtop/tsconfig.json
+++ b/components/Backtop/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Badge/package.json
+++ b/components/Badge/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/badge",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/utils": "workspace:*",

--- a/components/Badge/package.json
+++ b/components/Badge/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/badge",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Badge/package.json
+++ b/components/Badge/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Badge/tsconfig.json
+++ b/components/Badge/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Breadcrumb/package.json
+++ b/components/Breadcrumb/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/breadcrumb",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Breadcrumb/package.json
+++ b/components/Breadcrumb/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/breadcrumb",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Breadcrumb/package.json
+++ b/components/Breadcrumb/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Breadcrumb/tsconfig.json
+++ b/components/Breadcrumb/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/BreadcrumbItem/package.json
+++ b/components/BreadcrumbItem/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/breadcrumb-item",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/BreadcrumbItem/package.json
+++ b/components/BreadcrumbItem/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/breadcrumb-item",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/BreadcrumbItem/package.json
+++ b/components/BreadcrumbItem/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/BreadcrumbItem/tsconfig.json
+++ b/components/BreadcrumbItem/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Button/package.json
+++ b/components/Button/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/button",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Button/package.json
+++ b/components/Button/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/button",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Button/package.json
+++ b/components/Button/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Button/tsconfig.json
+++ b/components/Button/tsconfig.json
@@ -5,6 +5,7 @@
 		"noImplicitAny": true,
 		"strict": true,
 		"declaration": true,
+		"sourceMap": false,
 		"paths": {
 			"@ikun-ui/utils": ["../../utils/index.ts"]
 		}

--- a/components/ButtonGroup/package.json
+++ b/components/ButtonGroup/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/button-group",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/ButtonGroup/package.json
+++ b/components/ButtonGroup/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/ButtonGroup/package.json
+++ b/components/ButtonGroup/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/button-group",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/ButtonGroup/tsconfig.json
+++ b/components/ButtonGroup/tsconfig.json
@@ -5,6 +5,7 @@
 		"noImplicitAny": true,
 		"strict": true,
 		"declaration": true,
+		"sourceMap": false,
 		"paths": {
 			"@ikun-ui/utils": ["../../utils/index.ts"]
 		}

--- a/components/Card/package.json
+++ b/components/Card/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/card",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Card/package.json
+++ b/components/Card/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/card",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Card/package.json
+++ b/components/Card/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Card/tsconfig.json
+++ b/components/Card/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Checkbox/package.json
+++ b/components/Checkbox/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/checkbox",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/checkbox-group": "workspace:*",

--- a/components/Checkbox/package.json
+++ b/components/Checkbox/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/checkbox",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Checkbox/package.json
+++ b/components/Checkbox/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Checkbox/tsconfig.json
+++ b/components/Checkbox/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/CheckboxGroup/package.json
+++ b/components/CheckboxGroup/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/checkbox-group",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/CheckboxGroup/package.json
+++ b/components/CheckboxGroup/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/checkbox-group",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/CheckboxGroup/package.json
+++ b/components/CheckboxGroup/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/CheckboxGroup/tsconfig.json
+++ b/components/CheckboxGroup/tsconfig.json
@@ -5,6 +5,7 @@
 		"noImplicitAny": true,
 		"strict": true,
 		"declaration": true,
+		"sourceMap": false,
 		"paths": {
 			"@ikun-ui/utils": ["../../utils/index.ts"]
 		}

--- a/components/ClientOnly/package.json
+++ b/components/ClientOnly/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/client-only",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/ClientOnly/package.json
+++ b/components/ClientOnly/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/ClientOnly/package.json
+++ b/components/ClientOnly/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/client-only",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/ClientOnly/tsconfig.json
+++ b/components/ClientOnly/tsconfig.json
@@ -5,6 +5,7 @@
 		"noImplicitAny": true,
 		"strict": true,
 		"declaration": true,
+		"sourceMap": false,
 		"paths": {
 			"@ikun-ui/utils": ["../../utils/index.ts"]
 		}

--- a/components/Collapse/package.json
+++ b/components/Collapse/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/collapse",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Collapse/package.json
+++ b/components/Collapse/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/collapse",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Collapse/package.json
+++ b/components/Collapse/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Collapse/tsconfig.json
+++ b/components/Collapse/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/CollapseWrapper/package.json
+++ b/components/CollapseWrapper/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/collapse-wrapper",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/CollapseWrapper/package.json
+++ b/components/CollapseWrapper/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/collapse-wrapper",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/CollapseWrapper/package.json
+++ b/components/CollapseWrapper/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/CollapseWrapper/tsconfig.json
+++ b/components/CollapseWrapper/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Contextmenu/package.json
+++ b/components/Contextmenu/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/contextmenu",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Contextmenu/package.json
+++ b/components/Contextmenu/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Contextmenu/package.json
+++ b/components/Contextmenu/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/contextmenu",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Contextmenu/tsconfig.json
+++ b/components/Contextmenu/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Divider/package.json
+++ b/components/Divider/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/divider",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Divider/package.json
+++ b/components/Divider/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Divider/package.json
+++ b/components/Divider/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/divider",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Divider/tsconfig.json
+++ b/components/Divider/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Drawer/package.json
+++ b/components/Drawer/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/drawer",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Drawer/package.json
+++ b/components/Drawer/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/drawer",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/client-only": "workspace:*",

--- a/components/Drawer/package.json
+++ b/components/Drawer/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Drawer/tsconfig.json
+++ b/components/Drawer/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Ellipsis/package.json
+++ b/components/Ellipsis/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/ellipsis",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Ellipsis/package.json
+++ b/components/Ellipsis/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/ellipsis",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Ellipsis/package.json
+++ b/components/Ellipsis/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Ellipsis/tsconfig.json
+++ b/components/Ellipsis/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Empty/package.json
+++ b/components/Empty/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/empty",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Empty/package.json
+++ b/components/Empty/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/empty",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Empty/package.json
+++ b/components/Empty/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Empty/tsconfig.json
+++ b/components/Empty/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/EyeDropper/package.json
+++ b/components/EyeDropper/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/eye-dropper",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/utils": "workspace:*",

--- a/components/EyeDropper/package.json
+++ b/components/EyeDropper/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/EyeDropper/package.json
+++ b/components/EyeDropper/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/eye-dropper",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/EyeDropper/tsconfig.json
+++ b/components/EyeDropper/tsconfig.json
@@ -3,7 +3,8 @@
 	"compilerOptions": {
 		"noImplicitAny": false,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Grid/package.json
+++ b/components/Grid/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/grid",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Grid/package.json
+++ b/components/Grid/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/grid",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Grid/package.json
+++ b/components/Grid/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Grid/tsconfig.json
+++ b/components/Grid/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Icon/package.json
+++ b/components/Icon/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/icon",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/utils": "workspace:*",

--- a/components/Icon/package.json
+++ b/components/Icon/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/icon",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Icon/package.json
+++ b/components/Icon/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Icon/tsconfig.json
+++ b/components/Icon/tsconfig.json
@@ -4,6 +4,7 @@
 		"noImplicitAny": true,
 		"strict": true,
 		"declaration": true,
+		"sourceMap": false,
 		"lib": ["dom"]
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],

--- a/components/Infinite/package.json
+++ b/components/Infinite/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/infinite",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Infinite/package.json
+++ b/components/Infinite/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/infinite",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Infinite/package.json
+++ b/components/Infinite/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Infinite/tsconfig.json
+++ b/components/Infinite/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Input/package.json
+++ b/components/Input/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/input",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/button": "workspace:*",

--- a/components/Input/package.json
+++ b/components/Input/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/input",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Input/package.json
+++ b/components/Input/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Input/tsconfig.json
+++ b/components/Input/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Layout/package.json
+++ b/components/Layout/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/layout",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Layout/package.json
+++ b/components/Layout/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/layout",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Layout/package.json
+++ b/components/Layout/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Layout/tsconfig.json
+++ b/components/Layout/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Link/package.json
+++ b/components/Link/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/link",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Link/package.json
+++ b/components/Link/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/link",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Link/package.json
+++ b/components/Link/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Link/tsconfig.json
+++ b/components/Link/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Mask/package.json
+++ b/components/Mask/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/mask",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/utils": "workspace:*",

--- a/components/Mask/package.json
+++ b/components/Mask/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/mask",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Mask/package.json
+++ b/components/Mask/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Mask/tsconfig.json
+++ b/components/Mask/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Message/package.json
+++ b/components/Message/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -22,7 +22,8 @@
 	"scripts": {
 		"build": "npm run build:js",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Message/package.json
+++ b/components/Message/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/message",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -15,6 +15,10 @@
 		"svelte-kit",
 		"dx"
 	],
+	"files": [
+		"dist",
+		"package.json"
+	],
 	"scripts": {
 		"build": "npm run build:js",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
@@ -25,7 +29,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/notify": "workspace:*",

--- a/components/Message/package.json
+++ b/components/Message/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/message",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Message/tsconfig.json
+++ b/components/Message/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/MessageBox/package.json
+++ b/components/MessageBox/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/message-box",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/MessageBox/package.json
+++ b/components/MessageBox/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/message-box",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/button": "workspace:*",

--- a/components/MessageBox/package.json
+++ b/components/MessageBox/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/MessageBox/tsconfig.json
+++ b/components/MessageBox/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Modal/package.json
+++ b/components/Modal/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/modal",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Modal/package.json
+++ b/components/Modal/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Modal/package.json
+++ b/components/Modal/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/modal",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/button": "workspace:*",

--- a/components/Modal/tsconfig.json
+++ b/components/Modal/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Notification/package.json
+++ b/components/Notification/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/notify",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Notification/package.json
+++ b/components/Notification/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/notify",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Notification/package.json
+++ b/components/Notification/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Notification/tsconfig.json
+++ b/components/Notification/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Popconfirm/package.json
+++ b/components/Popconfirm/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/popconfirm",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Popconfirm/package.json
+++ b/components/Popconfirm/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Popconfirm/package.json
+++ b/components/Popconfirm/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/popconfirm",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Popconfirm/tsconfig.json
+++ b/components/Popconfirm/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Popover/package.json
+++ b/components/Popover/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/popover",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Popover/package.json
+++ b/components/Popover/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/popover",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/utils": "workspace:*",

--- a/components/Popover/package.json
+++ b/components/Popover/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Popover/tsconfig.json
+++ b/components/Popover/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Progress/package.json
+++ b/components/Progress/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/progress",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Progress/package.json
+++ b/components/Progress/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/progress",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Progress/package.json
+++ b/components/Progress/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Progress/tsconfig.json
+++ b/components/Progress/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Radio/package.json
+++ b/components/Radio/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/radio",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Radio/package.json
+++ b/components/Radio/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/radio",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Radio/package.json
+++ b/components/Radio/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Radio/tsconfig.json
+++ b/components/Radio/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/RadioGroup/package.json
+++ b/components/RadioGroup/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/radio-group",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/RadioGroup/package.json
+++ b/components/RadioGroup/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/RadioGroup/package.json
+++ b/components/RadioGroup/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/radio-group",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/RadioGroup/tsconfig.json
+++ b/components/RadioGroup/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Rate/package.json
+++ b/components/Rate/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/rate",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Rate/package.json
+++ b/components/Rate/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/rate",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Rate/package.json
+++ b/components/Rate/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Rate/tsconfig.json
+++ b/components/Rate/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Select/package.json
+++ b/components/Select/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/select",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Select/package.json
+++ b/components/Select/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/select",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Select/package.json
+++ b/components/Select/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Select/tsconfig.json
+++ b/components/Select/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Slider/package.json
+++ b/components/Slider/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/slider",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/utils": "workspace:*",

--- a/components/Slider/package.json
+++ b/components/Slider/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/slider",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Slider/package.json
+++ b/components/Slider/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Slider/tsconfig.json
+++ b/components/Slider/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Spin/package.json
+++ b/components/Spin/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/spin",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Spin/package.json
+++ b/components/Spin/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/spin",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/client-only": "workspace:*",

--- a/components/Spin/package.json
+++ b/components/Spin/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Spin/tsconfig.json
+++ b/components/Spin/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Switch/package.json
+++ b/components/Switch/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/switch",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Switch/package.json
+++ b/components/Switch/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Switch/package.json
+++ b/components/Switch/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/switch",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Switch/tsconfig.json
+++ b/components/Switch/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Tag/package.json
+++ b/components/Tag/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/tag",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Tag/package.json
+++ b/components/Tag/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/tag",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/Tag/package.json
+++ b/components/Tag/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Tag/tsconfig.json
+++ b/components/Tag/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/Tooltip/package.json
+++ b/components/Tooltip/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/tooltip",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/popover": "workspace:*",

--- a/components/Tooltip/package.json
+++ b/components/Tooltip/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/tooltip",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/Tooltip/package.json
+++ b/components/Tooltip/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/Tooltip/tsconfig.json
+++ b/components/Tooltip/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/components/VirtualList/package.json
+++ b/components/VirtualList/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/virtual-list",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "./src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",
@@ -14,6 +14,10 @@
 		"vue",
 		"svelte-kit",
 		"dx"
+	],
+	"files": [
+		"dist",
+		"package.json"
 	],
 	"scripts": {
 		"build": "npm run build:js && npm run build:svelte",
@@ -26,7 +30,7 @@
 		"main": "dist/index.js",
 		"module": "dist/index.js",
 		"svelte": "dist/index.js",
-		"types": "src/index.ts"
+		"types": "dist/index.d.ts"
 	},
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",

--- a/components/VirtualList/package.json
+++ b/components/VirtualList/package.json
@@ -2,8 +2,8 @@
 	"name": "@ikun-ui/virtual-list",
 	"version": "0.0.11",
 	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "src/index.ts",
+	"types": "src/index.d.ts",
 	"svelte": "dist/index.js",
 	"keywords": [
 		"svelte",

--- a/components/VirtualList/package.json
+++ b/components/VirtualList/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"types": "src/index.d.ts",
-	"svelte": "dist/index.js",
+	"svelte": "src/index.ts",
 	"keywords": [
 		"svelte",
 		"svelte3",
@@ -23,7 +23,8 @@
 		"build": "npm run build:js && npm run build:svelte",
 		"build:js": "tsc -p . --outDir dist/ --rootDir src/",
 		"build:svelte": "svelte-strip strip src/ dist",
-		"publish:npm": "pnpm publish --no-git-checks --access public"
+		"publish:pre": "node ../../scripts/pre-publish.js",
+		"publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/components/VirtualList/tsconfig.json
+++ b/components/VirtualList/tsconfig.json
@@ -4,7 +4,8 @@
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"strict": true,
-		"declaration": true
+		"declaration": true,
+		"sourceMap": false
 	},
 	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
 	"exclude": ["node_modules/*", "**/*.spec.ts"]

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
 		"typescript": "^5.2.2",
 		"unocss": "^0.56.5",
 		"vite": "^4.4.9",
+		"fs-extra": "11.1.1",
 		"vitest": "^0.34.4",
 		"playwright-chromium": "^1.36.2"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
       fast-glob:
         specifier: ^3.3.1
         version: 3.3.1
+      fs-extra:
+        specifier: 11.1.1
+        version: 11.1.1
       jsdom:
         specifier: ^22.1.0
         version: 22.1.0
@@ -1671,6 +1674,9 @@ importers:
 
   play:
     devDependencies:
+      '@baiwusanyu/alert':
+        specifier: 0.0.17
+        version: 0.0.17(ansi-colors@4.1.3)(moment@2.29.4)
       '@iconify-json/carbon':
         specifier: ^1.1.21
         version: 1.1.21
@@ -1946,6 +1952,18 @@ packages:
       '@babel/helper-string-parser': 7.22.5
       '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
+
+  /@baiwusanyu/alert@0.0.17(ansi-colors@4.1.3)(moment@2.29.4):
+    resolution: {integrity: sha512-MXtegNhQC26LViXUn83nHHG7xfhEbiKP+XV0hOutc8Zy/JmqXDBhL6U8UBExQWv/Nvh048E9EUn6IBdsKIW50A==}
+    dependencies:
+      '@ikun-ui/icon': 0.0.11(ansi-colors@4.1.3)(moment@2.29.4)
+      '@ikun-ui/utils': 0.0.11
+      baiwusanyu-utils: 1.0.16(ansi-colors@4.1.3)(moment@2.29.4)
+      clsx: 2.0.0
+    transitivePeerDependencies:
+      - ansi-colors
+      - moment
+    dev: true
 
   /@baiwusanyu/utils-com@1.0.16(ansi-colors@4.1.3)(hash-sum@2.0.0):
     resolution: {integrity: sha512-2FIcfCRSBxFJqDU8KVFdEMdzF7IiLQG7CCLEBHYVles7g8C6ztc3QPisfSrd06oQ0TmxP7B+/9yn7OAvOHjSYw==}
@@ -2542,6 +2560,21 @@ packages:
       local-pkg: 0.4.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@ikun-ui/icon@0.0.11(ansi-colors@4.1.3)(moment@2.29.4):
+    resolution: {integrity: sha512-s87eQwn5uE/mX+x3YTu673GcZa6+5N9TR2UQgWUuYUtD3v1Zt0vjla1MZC/7lacIDJnLcyKDpw6zYXHajTWl5g==}
+    dependencies:
+      '@ikun-ui/utils': 0.0.11
+      baiwusanyu-utils: 1.0.16(ansi-colors@4.1.3)(moment@2.29.4)
+      clsx: 2.0.0
+    transitivePeerDependencies:
+      - ansi-colors
+      - moment
+    dev: true
+
+  /@ikun-ui/utils@0.0.11:
+    resolution: {integrity: sha512-KCs6YI5Pcp8L6pkw2WEqvBpcDepgPDPZNxT4YC8kZ8fd1pyzUvoxvgTp0aVsZjKmfvQwAAvdvgJ9JZI6/oJN7A==}
     dev: true
 
   /@isaacs/cliui@8.0.2:
@@ -4136,7 +4169,6 @@ packages:
   /clsx@2.0.0:
     resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
     engines: {node: '>=6'}
-    dev: false
 
   /code-red@1.0.3:
     resolution: {integrity: sha512-kVwJELqiILQyG5aeuyKFbdsI1fmQy1Cmf7dQ8eGmVuJoaRVdwey7WaMknr2ZFeVSYSKT0rExsa8EGw0aoI/1QQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1674,9 +1674,6 @@ importers:
 
   play:
     devDependencies:
-      '@baiwusanyu/alert':
-        specifier: 0.0.17
-        version: 0.0.17(ansi-colors@4.1.3)(moment@2.29.4)
       '@iconify-json/carbon':
         specifier: ^1.1.21
         version: 1.1.21
@@ -1952,18 +1949,6 @@ packages:
       '@babel/helper-string-parser': 7.22.5
       '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
-
-  /@baiwusanyu/alert@0.0.17(ansi-colors@4.1.3)(moment@2.29.4):
-    resolution: {integrity: sha512-MXtegNhQC26LViXUn83nHHG7xfhEbiKP+XV0hOutc8Zy/JmqXDBhL6U8UBExQWv/Nvh048E9EUn6IBdsKIW50A==}
-    dependencies:
-      '@ikun-ui/icon': 0.0.11(ansi-colors@4.1.3)(moment@2.29.4)
-      '@ikun-ui/utils': 0.0.11
-      baiwusanyu-utils: 1.0.16(ansi-colors@4.1.3)(moment@2.29.4)
-      clsx: 2.0.0
-    transitivePeerDependencies:
-      - ansi-colors
-      - moment
-    dev: true
 
   /@baiwusanyu/utils-com@1.0.16(ansi-colors@4.1.3)(hash-sum@2.0.0):
     resolution: {integrity: sha512-2FIcfCRSBxFJqDU8KVFdEMdzF7IiLQG7CCLEBHYVles7g8C6ztc3QPisfSrd06oQ0TmxP7B+/9yn7OAvOHjSYw==}
@@ -2560,21 +2545,6 @@ packages:
       local-pkg: 0.4.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@ikun-ui/icon@0.0.11(ansi-colors@4.1.3)(moment@2.29.4):
-    resolution: {integrity: sha512-s87eQwn5uE/mX+x3YTu673GcZa6+5N9TR2UQgWUuYUtD3v1Zt0vjla1MZC/7lacIDJnLcyKDpw6zYXHajTWl5g==}
-    dependencies:
-      '@ikun-ui/utils': 0.0.11
-      baiwusanyu-utils: 1.0.16(ansi-colors@4.1.3)(moment@2.29.4)
-      clsx: 2.0.0
-    transitivePeerDependencies:
-      - ansi-colors
-      - moment
-    dev: true
-
-  /@ikun-ui/utils@0.0.11:
-    resolution: {integrity: sha512-KCs6YI5Pcp8L6pkw2WEqvBpcDepgPDPZNxT4YC8kZ8fd1pyzUvoxvgTp0aVsZjKmfvQwAAvdvgJ9JZI6/oJN7A==}
     dev: true
 
   /@isaacs/cliui@8.0.2:
@@ -4169,6 +4139,7 @@ packages:
   /clsx@2.0.0:
     resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
     engines: {node: '>=6'}
+    dev: false
 
   /code-red@1.0.3:
     resolution: {integrity: sha512-kVwJELqiILQyG5aeuyKFbdsI1fmQy1Cmf7dQ8eGmVuJoaRVdwey7WaMknr2ZFeVSYSKT0rExsa8EGw0aoI/1QQ==}

--- a/scripts/new-component.js
+++ b/scripts/new-component.js
@@ -126,7 +126,7 @@ async function writePkgJson(baseDir, originalCompName) {
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.d.ts",
-  "svelte": "dist/index.js",
+  "svelte": "src/index.ts",
   "keywords": [
     "svelte",
     "svelte3",
@@ -145,7 +145,8 @@ async function writePkgJson(baseDir, originalCompName) {
     "build": "npm run build:js && npm run build:svelte",
     "build:js": "tsc -p . --outDir dist/ --rootDir src/",
     "build:svelte": "svelte-strip strip src/ dist",
-    "publish:npm": "pnpm publish --no-git-checks --access public"
+    "publish:pre": "node ../../scripts/pre-publish.js",
+    "publish:npm": "pnpm run publish:pre && pnpm publish --no-git-checks --access public"
   },
   "publishConfig": {
 	"access": "public",

--- a/scripts/new-component.js
+++ b/scripts/new-component.js
@@ -124,8 +124,8 @@ async function writePkgJson(baseDir, originalCompName) {
   "name": "@ikun-ui/${originalCompName}",
   "version": "${version}",
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "svelte": "dist/index.js",
   "keywords": [
     "svelte",
@@ -137,6 +137,10 @@ async function writePkgJson(baseDir, originalCompName) {
     "svelte-kit",
     "dx"
   ],
+ "files": [
+  "dist",
+  "package.json"
+ ],
   "scripts": {
     "build": "npm run build:js && npm run build:svelte",
     "build:js": "tsc -p . --outDir dist/ --rootDir src/",
@@ -148,7 +152,7 @@ async function writePkgJson(baseDir, originalCompName) {
 	"main": "dist/index.js",
 	"module": "dist/index.js",
 	"svelte": "dist/index.js",
-	"types": "src/index.ts"
+	"types": "dist/index.d.ts"
   },
   "dependencies": {
     "@ikun-ui/icon": "workspace:*",

--- a/scripts/new-component.js
+++ b/scripts/new-component.js
@@ -124,8 +124,8 @@ async function writePkgJson(baseDir, originalCompName) {
   "name": "@ikun-ui/${originalCompName}",
   "version": "${version}",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "src/index.ts",
+  "types": "src/index.d.ts",
   "svelte": "dist/index.js",
   "keywords": [
     "svelte",

--- a/scripts/pre-publish.js
+++ b/scripts/pre-publish.js
@@ -1,0 +1,7 @@
+import path from 'path';
+import fs from 'fs-extra';
+const pathCWD = process.cwd();
+const packageJsonPath = path.join(pathCWD, 'package.json');
+const packageJson = fs.readJsonSync(packageJsonPath);
+packageJson.svelte = 'dist/index.js';
+fs.writeJsonSync(packageJsonPath, packageJson, { spaces: 4 });


### PR DESCRIPTION
1.The svelte field in `package.json` points to `src/index.ts` by default
This avoids the need to rebuild the component every time it is developed
2.Added ·`pre-publish`script, the function is to point the `svelte` field to `dist/index.js` to ensure that it can be used correctly by users