### PR TITLE
fix: Replace the $app/environment with esm-env

### DIFF
--- a/components/ClientOnly/package.json
+++ b/components/ClientOnly/package.json
@@ -36,7 +36,8 @@
 	"dependencies": {
 		"@ikun-ui/icon": "workspace:*",
 		"@ikun-ui/utils": "workspace:*",
-		"baiwusanyu-utils": "^1.0.16"
+		"baiwusanyu-utils": "^1.0.16",
+		"esm-env": "^1.0.0"
 	},
 	"devDependencies": {
 		"@tsconfig/svelte": "^5.0.2",

--- a/components/ClientOnly/src/index.svelte
+++ b/components/ClientOnly/src/index.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-	import { browser } from '$app/environment'
+	import { BROWSER } from 'esm-env';
 </script>
-{#if browser}
-	<slot></slot>
+
+{#if BROWSER}
+	<slot />
 {/if}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -596,6 +596,9 @@ importers:
       baiwusanyu-utils:
         specifier: ^1.0.16
         version: 1.0.16(ansi-colors@4.1.3)(moment@2.29.4)
+      esm-env:
+        specifier: ^1.0.0
+        version: 1.0.0
     devDependencies:
       '@tsconfig/svelte':
         specifier: ^5.0.2
@@ -4202,7 +4205,6 @@ packages:
 
   /esm-env@1.0.0:
     resolution: {integrity: sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==}
-    dev: true
 
   /esno@0.17.0:
     resolution: {integrity: sha512-w78cQGlptQfsBYfootUCitsKS+MD74uR5L6kNsvwVkJsfzEepIafbvWsx2xK4rcFP4IUftt4F6J8EhagUxX+Bg==}


### PR DESCRIPTION
Fix that components that use ClientOnly can only be used in svelte-kit