### PR TITLE
Fix docs typo (From > Form) in navigation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -57,7 +57,7 @@ const components = [
 				link: '/components/KCheckbox'
 			},
 			{
-				text: 'From',
+				text: 'Form',
 				link: '/components/KForm'
 			},
 			{


### PR DESCRIPTION
This pull request fixes a typo in the docs (From > Form)
see attached screenshot: 

![image](https://github.com/ikun-svelte/ikun-ui/assets/40198445/0762fc3f-3214-4c30-b72d-08786f34db04)
